### PR TITLE
Update grpc dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "grpcio==1.57",
+    "grpcio>=1.62.1",
     "protobuf>=4.22.0"
 ]
 
@@ -40,6 +40,6 @@ reportImportCycles = false
 reportPrivateUsage = false
 
 [build-system]
-requires = ["flit_core==3.7.1", "grpcio-tools>=1.51.1"]
+requires = ["flit_core==3.7.1", "grpcio-tools>=1.62.1"]
 build-backend = "_build.backend"
 backend-path = ["."]


### PR DESCRIPTION
This makes it possible to build/install on macOS with Apple Silicon and python 3.12